### PR TITLE
EFS & Existing Cluster Improvements

### DIFF
--- a/ci/cloudbees-core-existing-cluster.json
+++ b/ci/cloudbees-core-existing-cluster.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ParameterKey": "VPCID",
+    "ParameterValue": "override"
+  },
+  {
+    "ParameterKey": "K8sSubnetIds",
+    "ParameterValue": "override"
+  },
+  {
+    "ParameterKey": "ControlPlaneSecurityGroup",
+    "ParameterValue": "override"
+  },
+  {
+    "ParameterKey": "KubeConfigPath",
+    "ParameterValue": "override"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  }
+]

--- a/templates/cloudbees-core-efs.template.yaml
+++ b/templates/cloudbees-core-efs.template.yaml
@@ -10,6 +10,8 @@ Parameters:
     Type: String
   InitialNodeGroupSecurityGroup:
     Type: AWS::EC2::SecurityGroup::Id
+  ProvisionedThroughputInMibps:
+    Type: Number
   PrivateSubnet1ID:
     Type: AWS::EC2::Subnet::Id
   PrivateSubnet2ID:
@@ -21,33 +23,29 @@ Resources:
   EFSFileSystem:
     Type: AWS::EFS::FileSystem
     Properties: 
-      #Encrypted: Boolean
+      Encrypted: true
       FileSystemTags:
       - Key: Name
         Value: cloudbees-core-efs-filesystem
-      #KmsKeyId: String
       PerformanceMode: generalPurpose
-      ProvisionedThroughputInMibps: 160
+      ProvisionedThroughputInMibps: !Ref ProvisionedThroughputInMibps
       ThroughputMode: provisioned
   MountTargetPrivateSubnet1:
     Type: AWS::EFS::MountTarget
     Properties:
       FileSystemId: !Ref EFSFileSystem
-      #IpAddress: String
       SecurityGroups: [ !Ref InitialNodeGroupSecurityGroup ]
       SubnetId: !Ref PrivateSubnet1ID
   MountTargetPrivateSubnet2:
     Type: AWS::EFS::MountTarget
     Properties:
       FileSystemId: !Ref EFSFileSystem
-      #IpAddress: String
       SecurityGroups: [ !Ref InitialNodeGroupSecurityGroup ]
       SubnetId: !Ref PrivateSubnet2ID
   MountTargetPrivateSubnet3:
     Type: AWS::EFS::MountTarget
     Properties:
       FileSystemId: !Ref EFSFileSystem
-      #IpAddress: String
       SecurityGroups: [ !Ref InitialNodeGroupSecurityGroup ]
       SubnetId: !Ref PrivateSubnet3ID
   EFSProvisioner:
@@ -58,12 +56,13 @@ Resources:
       KubeConfigPath: !Ref KubeConfigPath
       KubeConfigKmsContext: !Ref KubeConfigKmsContext
       Chart: stable/efs-provisioner
-      Version: 0.10.0
       Name: efs-provisioner
       Namespace: efs-provisioner
       Values:
         efsProvisioner.efsFileSystemId: !Ref EFSFileSystem
         efsProvisioner.awsRegion: !Ref "AWS::Region"
+        efsProvisioner.provisionerName: aws-quickstart/aws-efs
+        efsProvisioner.storageClass.name: aws-efs
         nodeSelector.partition: masters
 
 Outputs:

--- a/templates/cloudbees-core-existing-cluster.template.yaml
+++ b/templates/cloudbees-core-existing-cluster.template.yaml
@@ -86,7 +86,7 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slash (/).
-    Default: quickstart-cloudbees-core/
+    Default: quickstart-cloudbees-core/submodules/quickstart-amazon-eks/
     Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       forward slash (/).
@@ -106,6 +106,8 @@ Resources:
         HelmLambdaArn: !GetAtt HelmLambda.Arn
         KubeConfigPath: !Ref KubeConfigPath
         KubeConfigKmsContext: !Ref KubeConfigKmsContext
+        #StorageType: gp2
+        #CustomValueYaml: https://raw.githubusercontent.com/schottsfired/my-custom-values/master/customValues.yaml
   CopyZips:
     Type: Custom::CopyZips
     Properties:

--- a/templates/cloudbees-core-existing-vpc.template.yaml
+++ b/templates/cloudbees-core-existing-vpc.template.yaml
@@ -780,13 +780,21 @@ Parameters:
     AllowedValues: ["gp2", "aws-efs"]
     Default: "aws-efs"
     Description: 
-      Type of storage to use for JENKINS_HOME data. Choices are efs (Amazon EFS) 
+      Type of storage to use for JENKINS_HOME data. Choices are aws-efs (Amazon EFS) 
       or gp2 (Amazon EBS). WARNING Amazon EBS doesn't provide high availability in case 
       of outage of an Availability Zone.
+  ProvisionedThroughputInMibps:
+    Type: Number
+    MinValue: 160
+    Default: 160
+    Description:
+      Amount of Amazon EFS provisioned throughput in Mibps. This value is not used 
+      when "gp2" (Amazon EBS) is selected as the storage type. The default value 
+      (160Mibps) is recommended.
   CustomValueYaml:
     Type: String
     Default: ''
-    Description: HTTP(S) or S3 URL which points to raw yaml containing "custom" 
+    Description: HTTP(S) or Amazon S3 URL which points to raw yaml containing "custom" 
       Helm values. Custom values are merged with "internal" (CloudFormation) 
       values during Helm operations such as install and upgrade.
   QSS3BucketName:
@@ -902,6 +910,7 @@ Resources:
         KubeConfigKmsContext: !Ref KubeConfigKmsContext
         StorageType: !Ref StorageType
         InitialNodeGroupSecurityGroup: !GetAtt EKSStack.Outputs.NodeGroupSecurityGroup
+        ProvisionedThroughputInMibps: !Ref ProvisionedThroughputInMibps
         CustomValueYaml: !Ref CustomValueYaml
         PrivateSubnet1ID: !Ref PrivateSubnet1ID
         PrivateSubnet2ID: !Ref PrivateSubnet2ID

--- a/templates/cloudbees-core-master.template.yaml
+++ b/templates/cloudbees-core-master.template.yaml
@@ -38,6 +38,7 @@ Metadata:
           - AgentNodeVolumeSize
           - KubernetesVersion
           - StorageType
+          - ProvisionedThroughputInMibps
           - CustomValueYaml
       - Label:
           default: AWS Quick Start configuration
@@ -96,6 +97,8 @@ Metadata:
         default: Kubernetes version
       StorageType:
         default: Storage type
+      ProvisionedThroughputInMibps:
+        default: EFS provisioned throughput
       CustomValueYaml:
         default: Link to custom Helm values
       QSS3BucketName:
@@ -805,13 +808,21 @@ Parameters:
     AllowedValues: ["gp2", "aws-efs"]
     Default: "aws-efs"
     Description: 
-      Type of storage to use for JENKINS_HOME data. Choices are efs (Amazon EFS) 
+      Type of storage to use for JENKINS_HOME data. Choices are aws-efs (Amazon EFS) 
       or gp2 (Amazon EBS). WARNING Amazon EBS doesn't provide high availability in case 
       of outage of an Availability Zone.)
+  ProvisionedThroughputInMibps:
+    Type: Number
+    MinValue: 160
+    Default: 160
+    Description:
+      Amount of Amazon EFS provisioned throughput in Mibps. This value is not used 
+      when "gp2" (Amazon EBS) is selected as the storage type. The default value 
+      (160Mibps) is recommended.
   CustomValueYaml:
     Type: String
     Default: ''
-    Description: HTTP(S) or S3 URL which points to raw yaml containing "custom" 
+    Description: HTTP(S) or Amazon S3 URL which points to raw yaml containing "custom" 
       Helm values. Custom values are merged with "internal" (CloudFormation) 
       values during Helm operations such as install and upgrade.
   QSS3BucketName:
@@ -898,6 +909,7 @@ Resources:
         PublicSubnet3ID: !GetAtt 'VPCStack.Outputs.PublicSubnet3ID'
         KubernetesVersion: !Ref KubernetesVersion
         StorageType: !Ref StorageType
+        ProvisionedThroughputInMibps: !Ref ProvisionedThroughputInMibps
         CustomValueYaml: !Ref CustomValueYaml
         MasterNodeInstanceType: !Ref MasterNodeInstanceType
         RegularNodeInstanceType: !Ref RegularNodeInstanceType

--- a/templates/cloudbees-core-workload.template.yaml
+++ b/templates/cloudbees-core-workload.template.yaml
@@ -16,6 +16,8 @@ Parameters:
     Type: String
   InitialNodeGroupSecurityGroup:
     Type: AWS::EC2::SecurityGroup::Id
+  ProvisionedThroughputInMibps:
+    Type: Number
   CustomValueYaml:
     Type: String
   PrivateSubnet1ID:
@@ -61,6 +63,7 @@ Resources:
         PrivateSubnet1ID: !Ref PrivateSubnet1ID
         PrivateSubnet2ID: !Ref PrivateSubnet2ID
         PrivateSubnet3ID: !Ref PrivateSubnet3ID
+        ProvisionedThroughputInMibps: !Ref ProvisionedThroughputInMibps
   NginxIngressController:
     Type: "Custom::Helm"
     Version: '1.0'


### PR DESCRIPTION
Refer to [CSWD-955](https://cloudbees.atlassian.net/browse/CSWD-955).

* Provisioned throughput exposed as a parameter in new VPC and existing VPC deployment templates
* EFS Provisioner version # removed in favor of `stable` w/ corresponding `storageClass.name` (refer to [CSWD-952](https://cloudbees.atlassian.net/browse/CSWD-952))
* Encrypted OOTB, using default auto-generated KMS key

**also fixed small issue with the existing cluster template ([CSWD-955](https://cloudbees.atlassian.net/browse/CSWD-955)), but waiting on updated example template there.
