### PR TITLE
Relocate EFS and Rename StorageType

### DIFF
--- a/ci/cloudbees-core-existing-vpc.json
+++ b/ci/cloudbees-core-existing-vpc.json
@@ -8,6 +8,34 @@
         "ParameterValue": "override"
     },
     {
+        "ParameterKey": "KubernetesVersion",
+        "ParameterValue": "override"
+    },
+    {
+        "ParameterKey": "StorageClassName",
+        "ParameterValue": "override"
+    },
+    {
+        "ParameterKey": "CustomValueYaml",
+        "ParameterValue": "override"
+    },
+    {
+        "ParameterKey": "NumberOfMasterNodes",
+        "ParameterValue": "override"
+    },
+    {
+        "ParameterKey": "NumberOfRegularNodes",
+        "ParameterValue": "override"
+    },
+    {
+        "ParameterKey": "NumberOfSpotNodes",
+        "ParameterValue": "override"
+    },
+    {
+        "ParameterKey": "RemoteAccessCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    },
+    {
         "ParameterKey": "PrivateSubnet1ID",
         "ParameterValue": "override"
     },

--- a/ci/cloudbees-core-new-vpc.json
+++ b/ci/cloudbees-core-new-vpc.json
@@ -8,7 +8,11 @@
         "ParameterValue": "override"
     },
     {
-        "ParameterKey": "StorageType",
+        "ParameterKey": "StorageClassName",
+        "ParameterValue": "override"
+    },
+    {
+        "ParameterKey": "CustomValueYaml",
         "ParameterValue": "override"
     },
     {

--- a/ci/cloudbees-core-workload.json
+++ b/ci/cloudbees-core-workload.json
@@ -16,31 +16,11 @@
         "ParameterValue": "override"
     },
     {
-        "ParameterKey": "StorageType",
-        "ParameterValue": "override"
-    },
-    {
-        "ParameterKey": "InitialNodeGroupSecurityGroup",
+        "ParameterKey": "StorageClassName",
         "ParameterValue": "override"
     },
     {
         "ParameterKey": "CustomValueYaml",
         "ParameterValue": "override"
-    },
-    {
-        "ParameterKey": "PrivateSubnet1ID",
-        "ParameterValue": "override"
-    },
-    {
-        "ParameterKey": "PrivateSubnet2ID",
-        "ParameterValue": "override"
-    },
-    {
-        "ParameterKey": "PrivateSubnet3ID",
-        "ParameterValue": "override"
-    },
-    {
-        "ParameterKey": "QSS3BucketName",
-        "ParameterValue": "$[taskcat_autobucket]"
     }
 ]

--- a/examples/customValues.yaml
+++ b/examples/customValues.yaml
@@ -1,0 +1,2 @@
+OperationsCenter:
+  Memory: 3G

--- a/templates/cloudbees-core-existing-cluster.template.yaml
+++ b/templates/cloudbees-core-existing-cluster.template.yaml
@@ -106,7 +106,7 @@ Resources:
         HelmLambdaArn: !GetAtt HelmLambda.Arn
         KubeConfigPath: !Ref KubeConfigPath
         KubeConfigKmsContext: !Ref KubeConfigKmsContext
-        #StorageType: gp2
+        #StorageClassName: gp2
         #CustomValueYaml: https://raw.githubusercontent.com/schottsfired/my-custom-values/master/customValues.yaml
   CopyZips:
     Type: Custom::CopyZips

--- a/templates/cloudbees-core-existing-vpc.template.yaml
+++ b/templates/cloudbees-core-existing-vpc.template.yaml
@@ -36,7 +36,7 @@ Metadata:
           - MasterNodeVolumeSize
           - AgentNodeVolumeSize
           - KubernetesVersion
-          - StorageType
+          - StorageClassName
           - CustomValueYaml
       - Label:
           default: AWS Quick Start configuration
@@ -91,8 +91,8 @@ Metadata:
         default: Agent node EBS volume size
       KubernetesVersion:
         default: Kubernetes version
-      StorageType:
-        default: Storage Type
+      StorageClassName:
+        default: Kubernetes Storage Class Name
       CustomValueYaml:
         default: Link to custom Helm values
       QSS3BucketName:
@@ -775,14 +775,14 @@ Parameters:
     AllowedValues: [ "1.14", "1.13", "1.12" ]
     Default: "1.14"
     Description: The Kubernetes control plane version
-  StorageType:
+  StorageClassName:
     Type: String
     AllowedValues: ["gp2", "aws-efs"]
     Default: "aws-efs"
     Description: 
-      Type of storage to use for JENKINS_HOME data. Choices are aws-efs (Amazon EFS) 
-      or gp2 (Amazon EBS). WARNING Amazon EBS doesn't provide high availability in case 
-      of outage of an Availability Zone.
+      Kubernetes Storage Class name to use for JENKINS_HOME data. Choices are aws-efs 
+      (Amazon EFS) or gp2 (Amazon EBS). WARNING Amazon EBS doesn't provide high 
+      availability in case of outage of an Availability Zone.
   ProvisionedThroughputInMibps:
     Type: Number
     MinValue: 160
@@ -845,6 +845,9 @@ Rules:
              - ap-south-1
           - !Ref 'AWS::Region'
 
+Conditions:
+  EFSCondition: !Equals [!Ref 'StorageClassName', 'aws-efs']
+
 Resources:
   EKSStack:
     Type: AWS::CloudFormation::Stack
@@ -898,6 +901,20 @@ Resources:
         KubernetesVersion: !Ref KubernetesVersion
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
+  EFSStack:
+    Condition: EFSCondition
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/cloudbees-core-efs.template.yaml"
+      Parameters:
+        HelmLambdaArn: !GetAtt EKSStack.Outputs.HelmLambdaArn
+        KubeConfigPath: !GetAtt EKSStack.Outputs.KubeConfigPath
+        KubeConfigKmsContext: !Ref KubeConfigKmsContext
+        InitialNodeGroupSecurityGroup: !GetAtt EKSStack.Outputs.NodeGroupSecurityGroup
+        PrivateSubnet1ID: !Ref PrivateSubnet1ID
+        PrivateSubnet2ID: !Ref PrivateSubnet2ID
+        PrivateSubnet3ID: !Ref PrivateSubnet3ID
+        ProvisionedThroughputInMibps: !Ref ProvisionedThroughputInMibps
   CloudBeesCoreStack:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -908,15 +925,8 @@ Resources:
         HelmLambdaArn: !GetAtt EKSStack.Outputs.HelmLambdaArn
         KubeConfigPath: !GetAtt EKSStack.Outputs.KubeConfigPath
         KubeConfigKmsContext: !Ref KubeConfigKmsContext
-        StorageType: !Ref StorageType
-        InitialNodeGroupSecurityGroup: !GetAtt EKSStack.Outputs.NodeGroupSecurityGroup
-        ProvisionedThroughputInMibps: !Ref ProvisionedThroughputInMibps
+        StorageClassName: !Ref StorageClassName
         CustomValueYaml: !Ref CustomValueYaml
-        PrivateSubnet1ID: !Ref PrivateSubnet1ID
-        PrivateSubnet2ID: !Ref PrivateSubnet2ID
-        PrivateSubnet3ID: !Ref PrivateSubnet3ID
-        QSS3BucketName: !Ref QSS3BucketName
-        QSS3KeyPrefix: !Ref QSS3KeyPrefix
 
 Outputs:
   CloudBeesJenkinsOperationsCenterUrl:

--- a/templates/cloudbees-core-master.template.yaml
+++ b/templates/cloudbees-core-master.template.yaml
@@ -37,7 +37,7 @@ Metadata:
           - MasterNodeVolumeSize
           - AgentNodeVolumeSize
           - KubernetesVersion
-          - StorageType
+          - StorageClassName
           - ProvisionedThroughputInMibps
           - CustomValueYaml
       - Label:
@@ -95,8 +95,8 @@ Metadata:
         default: Agent node EBS volume size
       KubernetesVersion:
         default: Kubernetes version
-      StorageType:
-        default: Storage type
+      StorageClassName:
+        default: Kubernetes Storage Class Name
       ProvisionedThroughputInMibps:
         default: EFS provisioned throughput
       CustomValueYaml:
@@ -803,14 +803,14 @@ Parameters:
     AllowedValues: [ "1.14", "1.13", "1.12" ]
     Default: "1.14"
     Description: The Kubernetes control plane version
-  StorageType:
+  StorageClassName:
     Type: String
     AllowedValues: ["gp2", "aws-efs"]
     Default: "aws-efs"
     Description: 
-      Type of storage to use for JENKINS_HOME data. Choices are aws-efs (Amazon EFS) 
-      or gp2 (Amazon EBS). WARNING Amazon EBS doesn't provide high availability in case 
-      of outage of an Availability Zone.)
+      Kubernetes Storage Class name to use for JENKINS_HOME data. Choices are aws-efs 
+      (Amazon EFS) or gp2 (Amazon EBS). WARNING Amazon EBS doesn't provide high 
+      availability in case of outage of an Availability Zone.
   ProvisionedThroughputInMibps:
     Type: Number
     MinValue: 160
@@ -908,7 +908,7 @@ Resources:
         PublicSubnet2ID: !GetAtt 'VPCStack.Outputs.PublicSubnet2ID'
         PublicSubnet3ID: !GetAtt 'VPCStack.Outputs.PublicSubnet3ID'
         KubernetesVersion: !Ref KubernetesVersion
-        StorageType: !Ref StorageType
+        StorageClassName: !Ref StorageClassName
         ProvisionedThroughputInMibps: !Ref ProvisionedThroughputInMibps
         CustomValueYaml: !Ref CustomValueYaml
         MasterNodeInstanceType: !Ref MasterNodeInstanceType

--- a/templates/cloudbees-core-workload.template.yaml
+++ b/templates/cloudbees-core-workload.template.yaml
@@ -12,58 +12,12 @@ Parameters:
     Type: String
   KubeConfigKmsContext:
     Type: String
-  StorageType:
+  StorageClassName:
     Type: String
-  InitialNodeGroupSecurityGroup:
-    Type: AWS::EC2::SecurityGroup::Id
-  ProvisionedThroughputInMibps:
-    Type: Number
   CustomValueYaml:
     Type: String
-  PrivateSubnet1ID:
-    Type: AWS::EC2::Subnet::Id
-  PrivateSubnet2ID:
-    Type: AWS::EC2::Subnet::Id
-  PrivateSubnet3ID:
-    Type: AWS::EC2::Subnet::Id
-  QSS3BucketName:
-    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
-      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
-      (-).
-    Default: aws-quickstart
-    Description: S3 bucket name for the Quick Start assets. This string can include
-      numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start
-      or end with a hyphen (-).
-    Type: String
-  QSS3KeyPrefix:
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
-    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slash (/).
-    Default: quickstart-cloudbees-core/
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
-      forward slash (/).
-    Type: String
-
-Conditions:
-  EFSCondition: !Equals [!Ref 'StorageType', 'aws-efs']
 
 Resources:
-  EFSStack:
-    Condition: EFSCondition
-    Type: AWS::CloudFormation::Stack
-    Properties:
-      TemplateURL: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/cloudbees-core-efs.template.yaml"
-      Parameters:
-        HelmLambdaArn: !Ref HelmLambdaArn
-        KubeConfigPath: !Ref KubeConfigPath
-        KubeConfigKmsContext: !Ref KubeConfigKmsContext
-        InitialNodeGroupSecurityGroup: !Ref InitialNodeGroupSecurityGroup
-        PrivateSubnet1ID: !Ref PrivateSubnet1ID
-        PrivateSubnet2ID: !Ref PrivateSubnet2ID
-        PrivateSubnet3ID: !Ref PrivateSubnet3ID
-        ProvisionedThroughputInMibps: !Ref ProvisionedThroughputInMibps
   NginxIngressController:
     Type: "Custom::Helm"
     Version: '1.0'
@@ -123,7 +77,7 @@ Resources:
             subPath: .cloudbees-referrer.txt
             readOnly: true
         Persistence:
-          StorageClass: ${StorageType}
+          StorageClass: ${StorageClassName}
         NetworkPolicy:
           ingressControllerSelector:
             - namespaceSelector:


### PR DESCRIPTION
Refer to:
* [CSWD-1072](https://cloudbees.atlassian.net/browse/CSWD-1072)

Moved EFS to the Existing Cluster template. This eliminates the possibility of deleting EFS when the CloudBees Core workload stack is deleted (e.g. during advanced troubleshooting).

Other:

Renamed `StorageType` to `StorageClassName` to be more descriptive.

Added an example of `customValues.yaml`.